### PR TITLE
Add per-job duration and class logging

### DIFF
--- a/src/tj_lavin/runner.cr
+++ b/src/tj_lavin/runner.cr
@@ -26,21 +26,25 @@ module TJLavin
             Log.notice { "Subscribing to queue: #{queue_name}" }
 
             q.subscribe(no_ack: false, block: false) do |msg|
-              Log.notice { "Received: #{msg.body_io}" }
+              body = msg.body_io.to_s
+              message = JSON.parse(body)
+              job_class = message["class"].as_s
 
-              message = JSON.parse(msg.body_io.to_s)
+              Log.notice { "Received: #{body}" }
 
-              job_run = JobRun.new(message["class"].as_s)
+              started_at = Time.monotonic
+              job_run = JobRun.new(job_class)
               job_run.config = array_to_hash.call(message["args"].as_a.map(&.as_s))
               job_instance = job_run.run
+              duration_ms = (Time.monotonic - started_at).total_milliseconds.to_i64
 
               if job_instance.exception
                 ch.basic_reject(msg.delivery_tag, requeue: false)
+                Log.notice { {message: "Failed", class: job_class, duration_ms: duration_ms} }
               else
                 ch.basic_ack(msg.delivery_tag)
+                Log.notice { {message: "Done", class: job_class, duration_ms: duration_ms} }
               end
-
-              Log.notice { "Done" }
             rescue e
               Log.notice { "Error: #{e.message}".colorize(:red) }
               ch.basic_reject(msg.delivery_tag, requeue: false)

--- a/src/tj_lavin/runner.cr
+++ b/src/tj_lavin/runner.cr
@@ -27,10 +27,10 @@ module TJLavin
 
             q.subscribe(no_ack: false, block: false) do |msg|
               body = msg.body_io.to_s
+              Log.notice { "Received: #{body}" }
+
               message = JSON.parse(body)
               job_class = message["class"].as_s
-
-              Log.notice { "Received: #{body}" }
 
               started_at = Time.monotonic
               job_run = JobRun.new(job_class)
@@ -40,10 +40,14 @@ module TJLavin
 
               if job_instance.exception
                 ch.basic_reject(msg.delivery_tag, requeue: false)
-                Log.notice { {message: "Failed", class: job_class, duration_ms: duration_ms} }
+                Log.with_context(class: job_class, duration_ms: duration_ms) do
+                  Log.notice { "Failed" }
+                end
               else
                 ch.basic_ack(msg.delivery_tag)
-                Log.notice { {message: "Done", class: job_class, duration_ms: duration_ms} }
+                Log.with_context(class: job_class, duration_ms: duration_ms) do
+                  Log.notice { "Done" }
+                end
               end
             rescue e
               Log.notice { "Error: #{e.message}".colorize(:red) }


### PR DESCRIPTION
## Summary

- Adds `duration_ms` and `class` fields to the "Done" and "Failed" log lines in the consumer loop
- Uses `Time.monotonic` for accurate elapsed time measurement
- Failed jobs now log "Failed" instead of "Done" for easier filtering

### Before
```json
{"message": "Received: {\"class\":\"MyWorker\", ...}"}
{"message": "Done"}
```

### After
```json
{"message": "Received: {\"class\":\"MyWorker\", ...}"}
{"message": "Done", "class": "MyWorker", "duration_ms": 42}
```

## Test plan

- [ ] Deploy to a staging worker and verify "Done"/"Failed" lines include `class` and `duration_ms`
- [ ] Verify `duration_ms` values are reasonable (sub-second for fast jobs, higher for slow ones)
- [ ] Confirm log format is valid JSON when using structured logging

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)